### PR TITLE
#54 : AESEncrypt and Decrypt functions are now declared immutable

### DIFF
--- a/encryption_package/src/AESDecrypt.cpp
+++ b/encryption_package/src/AESDecrypt.cpp
@@ -117,6 +117,13 @@ class AESDecryptFactory : public ScalarFunctionFactory
         const VerticaType &t = argTypes.getColumnType(0);
         returnType.addVarchar(t.getStringLength());
     }
+	
+public:
+    AESDecryptFactory() 
+    {
+        vol = IMMUTABLE;
+    }
+    
 };
 
 RegisterFactory(AESDecryptFactory);

--- a/encryption_package/src/AESEncrypt.cpp
+++ b/encryption_package/src/AESEncrypt.cpp
@@ -121,6 +121,13 @@ class AESEncryptFactory : public ScalarFunctionFactory
 	// I believe it's faster than computing the length and round. 
         returnType.addVarchar(t.getStringLength()+AES_BLOCK_SIZE);
     }
+	
+public:
+    AESEncryptFactory() 
+    {
+        vol = IMMUTABLE;
+    }
+
 };
 
 RegisterFactory(AESEncryptFactory);


### PR DESCRIPTION
#54 : AESEncrypt and Decrypt functions are now declared immutable. As far I understand, both functions return the same results given the same inputs, so they are indeed immutable.
This will allow their use in Vertica column default expressions, which require immutable functions.
