### PR TITLE
The encryption_package can now be updated without uninstalling it first

### DIFF
--- a/encryption_package/ddl/install.sql
+++ b/encryption_package/ddl/install.sql
@@ -2,8 +2,8 @@ select version();
 
 \set libfile '\''`pwd`'/lib/Encryption.so\'';
 
-CREATE LIBRARY Encryption as :libfile;
-CREATE FUNCTION AESEncrypt as language 'C++' name 'AESEncryptFactory' library Encryption;
-CREATE FUNCTION AESDecrypt as language 'C++' name 'AESDecryptFactory' library Encryption;
+CREATE OR REPLACE LIBRARY Encryption as :libfile;
+CREATE OR REPLACE FUNCTION AESEncrypt as language 'C++' name 'AESEncryptFactory' library Encryption;
+CREATE OR REPLACE FUNCTION AESDecrypt as language 'C++' name 'AESDecryptFactory' library Encryption;
 
 


### PR DESCRIPTION
As detailed in issue #56, the encryption_package couldn't be updated without uninstalling it first.
This was problematic when the functions were used in Vertica column default expression, because dropping a library used by a default expression caused the whole table to be lost.

Solved the issue by using a 'CREATE OR REPLACE' statement instead of a simple 'CREATE'.