### PR TITLE
AESEncrypt and AESDecrypt functions shoud be public by default

### DIFF
--- a/encryption_package/ddl/install.sql
+++ b/encryption_package/ddl/install.sql
@@ -3,7 +3,11 @@ select version();
 \set libfile '\''`pwd`'/lib/Encryption.so\'';
 
 CREATE LIBRARY Encryption as :libfile;
+
 CREATE FUNCTION AESEncrypt as language 'C++' name 'AESEncryptFactory' library Encryption;
+GRANT EXECUTE ON FUNCTION AESEncrypt(varchar, varchar) TO PUBLIC;
+
 CREATE FUNCTION AESDecrypt as language 'C++' name 'AESDecryptFactory' library Encryption;
+GRANT EXECUTE ON FUNCTION AESDecrypt(varchar, varchar) TO PUBLIC;
 
 


### PR DESCRIPTION
When installing the encryption_package, the AESEncrypt and AESDecrypt functions usage is restricted to the user installing it.

Since these functions are immutable, and do not affect the database structure, and that the account used to install is probably not the one which will use them, it seems to make sense to make them public.