### PR TITLE
compatlib_function - ConnectBy supports VARCHAR inputs

### DIFF
--- a/compatlib_functions/Makefile
+++ b/compatlib_functions/Makefile
@@ -8,6 +8,7 @@
 
 SDK?=/opt/vertica/sdk
 VSQL?=vsql
+COMPATLIB_DEBUG = 0
 
 VERTICA_SDK_INCLUDE = $(SDK)/include
 SIMULATOR_PATH = $(SDK)/simulator
@@ -23,7 +24,7 @@ BUILD_FILES      = build/Vertica.o \
 PACKAGE_LIBNAME   = lib/CompatLib.so
 
 CXX=g++
-CXXFLAGS=-g -D HAVE_LONG_LONG_INT_64 -c -I ../include -Wall -Wno-unused-value -fPIC -I $(VERTICA_SDK_INCLUDE) -I $(THIRD_PARTY_INCLUDE)
+CXXFLAGS=-g -DHAVE_LONG_LONG_INT_64 -D_GLIBCXX_USE_CXX11_ABI=0 -DCOMPATLIB_DEBUG=$(COMPATLIB_DEBUG) -c -I ../include -Wall -Wno-unused-value -fPIC -std=c++11 -I $(VERTICA_SDK_INCLUDE) -I $(THIRD_PARTY_INCLUDE)
 LDFLAGS=-shared
 
 # add optimization if not a debug build
@@ -37,9 +38,9 @@ endif
 all: $(PACKAGE_LIBNAME)
 
 # Main target that builds the package library
-$(PACKAGE_LIBNAME): $(BUILD_FILES) 
+$(PACKAGE_LIBNAME): $(BUILD_FILES)
 	mkdir -p lib
-	$(CXX) $(LDFLAGS) -o $@ $(BUILD_FILES) 
+	$(CXX) $(LDFLAGS) -o $@ $(BUILD_FILES)
 
 # rule to make build/XXX.so from src/XXX.so
 build/%.o: src/%.cpp
@@ -54,7 +55,7 @@ build/Vertica.o: $(VERTICA_SDK_INCLUDE)/Vertica.cpp
 # example rule to make build/XX.o from third-party/src/*.c
 #build/%.o: $(THIRD_PARTY)/src/%.c
 #	@mkdir -p build
-#	$(CXX) $(CXXFLAGS) $< -o $@ 
+#	$(CXX) $(CXXFLAGS) $< -o $@
 
 
 # Targets to install and uninstall the library and functions
@@ -88,5 +89,4 @@ sim_test: all simulator
 # build the simulator (in SIMULATOR_PATH) and simlink it here
 simulator:
 	$(MAKE) -C $(SIMULATOR_PATH)
-	ln -f -s $(SIMULATOR_PATH)/vsim 
-
+	ln -f -s $(SIMULATOR_PATH)/vsim

--- a/compatlib_functions/ddl/install.sql
+++ b/compatlib_functions/ddl/install.sql
@@ -3,7 +3,8 @@ select version();
 \set libfile '\''`pwd`'/lib/CompatLib.so\'';
 CREATE LIBRARY CompatLib AS :libfile;
 
-CREATE TRANSFORM FUNCTION connect_by_path AS LANGUAGE 'C++' NAME 'ConnectByFactory' LIBRARY CompatLib;
+CREATE TRANSFORM FUNCTION connect_by_path AS LANGUAGE 'C++' NAME 'ConnectByIntFactory' LIBRARY CompatLib;
+CREATE TRANSFORM FUNCTION connect_by_path AS LANGUAGE 'C++' NAME 'ConnectByVarcharFactory' LIBRARY CompatLib;
 CREATE TRANSFORM FUNCTION transpose       AS LANGUAGE 'C++' NAME 'TransposeFactory' LIBRARY CompatLib;
 
 -- Add more as needed
@@ -11,4 +12,3 @@ CREATE TRANSFORM FUNCTION group_generator_3 AS LANGUAGE 'C++' NAME 'GroupGenerat
 CREATE TRANSFORM FUNCTION group_generator_3 AS LANGUAGE 'C++' NAME 'GroupGeneratorFactoryFVF' LIBRARY CompatLib;
 CREATE TRANSFORM FUNCTION group_generator_4 AS LANGUAGE 'C++' NAME 'GroupGeneratorFactoryVVVV' LIBRARY CompatLib;
 CREATE TRANSFORM FUNCTION group_generator_4 AS LANGUAGE 'C++' NAME 'GroupGeneratorFactoryFVFV' LIBRARY CompatLib;
-

--- a/compatlib_functions/examples/connect_by_path.sql
+++ b/compatlib_functions/examples/connect_by_path.sql
@@ -9,4 +9,6 @@ commit;
 
 select connect_by_path(supervisor_id, id, name, ' >> ') over () from company;
 
+select connect_by_path(supervisor_id::VARCHAR, id::VARCHAR, name, ' >> ') over () from company;
+
 drop table company;

--- a/compatlib_functions/src/ConnectBy.cpp
+++ b/compatlib_functions/src/ConnectBy.cpp
@@ -1,54 +1,67 @@
 #include "Vertica.h"
-#include <sstream>
+#include <string>
 #include <map>
 
 using namespace Vertica;
 using namespace std;
 
 
-const int WIDTH = 2000;
+const int WIDTH = 65000;
 
 class ConnectBy : public TransformFunction
 {
+    BaseDataOID argTypeOID;  // data type OID of parent ID and child ID
+
+    virtual void setup(ServerInterface &srvInterface, const SizedColumnTypes &argTypes)
+    {
+        // Get data type OID of parent ID and child ID
+        const VerticaType argType = argTypes.getColumnType(0);
+        argTypeOID = argType.getTypeOid();
+    }
+
     virtual void processPartition(ServerInterface &srvInterface,
                                   PartitionReader &input_reader,
                                   PartitionWriter &output_writer)
     {
-    	map<vint, vint> parent;
-    	map<vint, string> label;
-    	map<vint, string> separator;
-
+    	map<string, string> parent;
+    	map<string, string> label;
+    	map<string, string> separator;
 
     	if (input_reader.getNumCols() != 4)
             vt_report_error(0, "Function only accepts 4 argument, but %zu provided", input_reader.getNumCols());
 
+        string childValue = "";
+
         do {
-            parent[input_reader.getIntRef(1)] = input_reader.getIntRef(0);
-            label[input_reader.getIntRef(1)] = input_reader.getStringRef(2).str();
-            separator[input_reader.getIntRef(1)] = input_reader.getStringRef(3).str();
+            childValue = getArgValueAsString(input_reader, 1);
+            if (childValue == "")
+                continue;
 
-            std::string inString = input_reader.getStringRef(2).str();
+            parent[childValue] = getArgValueAsString(input_reader, 0);
+            label[childValue] = input_reader.getStringRef(2).str();
+            separator[childValue] = input_reader.getStringRef(3).str();
 
+            //std::string inString = input_reader.getStringRef(2).str();
             //srvInterface.log(" adding %s ", inString.c_str());
-
-
         } while (input_reader.next());
         //srvInterface.log("1");
         // exit(0);
 
-        map<vint, string> cache;
-        map<vint, vint> depth;
-        map<vint, string>::iterator p;
+        map<string, string> cache;
+        map<string, vint> depth;
+        map<string, string>::iterator p;
 
         for (p = label.begin(); p != label.end(); ++p) {
         	if (cache.count(p->first) == 0) {
 
         		string output = p->second;
         		vint current_depth = 0;
-        		vint current = parent[p->first];
-        		while (current != 0 ) {
+        		string current = parent[p->first];
+        		while (current != "") {
 
-        	        srvInterface.log("working on %lld", current);
+#if COMPATLIB_DEBUG
+        	        srvInterface.log("working on %s", current.c_str());
+#endif
 
 					if (cache.count(current) > 0 ) {
         				// Found the parent's path in the cache
@@ -67,26 +80,57 @@ class ConnectBy : public TransformFunction
         		depth[p->first] = current_depth;
         	}
 
-            srvInterface.log("attempting to output %lld", p->first);
+#if COMPATLIB_DEBUG
+            srvInterface.log("attempting to output %s", p->first.c_str());
+#endif
 
-        	output_writer.setInt(0,p->first);
-        	output_writer.setInt(1,depth[p->first]);
+            switch(argTypeOID) {
+            case VarcharOID: {
+                VString &word = output_writer.getStringRef(0);
+                word.copy(p->first);
+                break;
+            }
+            case Int8OID:
+                output_writer.setInt(0, stoll(p->first));
+                break;
+            default:
+                break;
+            }
+        	output_writer.setInt(1, depth[p->first]);
 			VString &word = output_writer.getStringRef(2);
 			word.copy(cache[p->first]);
 			output_writer.next();
         }
 
-
     }
 
-
+private:
+    string getArgValueAsString(PartitionReader &input_reader, size_t idx)
+    {
+        string value = "";
+        if (!input_reader.isNull(idx)) {
+            switch(argTypeOID) {
+            case VarcharOID:
+                value = input_reader.getStringRef(idx).str();
+                break;
+            case Int8OID: {
+                vint intValue = input_reader.getIntRef(idx);
+                value = to_string(intValue);
+                break;
+            }
+            default:
+                break;
+            }
+        }
+        return value;
+    }
 };
 
-
-class ConnectByFactory : public TransformFunctionFactory
+// This factory accepts function calls with integer arguments for parent ID and child ID
+class ConnectByIntFactory : public TransformFunctionFactory
 {
-    // Tell Vertica that we take in a row with 5 inputs (parent ID, child ID, label, separator,
-	// and return a row with 2 strings (id, path)
+    // Tell Vertica that we take in a row with 4 inputs (parent ID, child ID, label, separator)
+	// and return a row with 3 values (id, depth, path)
     virtual void getPrototype(ServerInterface &srvInterface, ColumnTypes &argTypes, ColumnTypes &returnType)
     {
         argTypes.addInt();
@@ -105,9 +149,9 @@ class ConnectByFactory : public TransformFunctionFactory
                                const SizedColumnTypes &input_types,
                                SizedColumnTypes &output_types)
     {
-        // Error out if we're called with anything but 1 argument
+        // Error out if we're called with anything not 4 arguments
         if (input_types.getColumnCount() != 4)
-            vt_report_error(0, "Function only accepts 3 arguments, but %zu provided", input_types.getColumnCount());
+            vt_report_error(0, "Function only accepts 4 arguments, but %zu provided", input_types.getColumnCount());
 
 
         // Our output size will never be more than the input size
@@ -121,6 +165,43 @@ class ConnectByFactory : public TransformFunctionFactory
 
 };
 
-RegisterFactory(ConnectByFactory);
+RegisterFactory(ConnectByIntFactory);
 
 
+// This factory accepts function calls with varchar arguments for parent ID and child ID
+class ConnectByVarcharFactory : public TransformFunctionFactory
+{
+    // Tell Vertica that we take in a row with 4 inputs (parent ID, child ID, label, separator)
+	// and return a row with 3 values (id, depth, path)
+    virtual void getPrototype(ServerInterface &srvInterface, ColumnTypes &argTypes, ColumnTypes &returnType)
+    {
+        argTypes.addVarchar();  // parent ID
+        argTypes.addVarchar();  // child ID
+        argTypes.addVarchar();  // label
+        argTypes.addVarchar();  // separator
+
+        returnType.addVarchar();  // id
+        returnType.addInt();      // depth
+        returnType.addVarchar();  // separator
+    }
+
+    // Tell Vertica what our return string length will be, given the input string length
+    virtual void getReturnType(ServerInterface &srvInterface,
+                               const SizedColumnTypes &input_types,
+                               SizedColumnTypes &output_types)
+    {
+        // Error out if we're called with anything not 4 arguments
+        if (input_types.getColumnCount() != 4)
+            vt_report_error(0, "Function only accepts 4 arguments, but %zu provided", input_types.getColumnCount());
+
+        output_types.addVarchar(WIDTH, "identifier");
+        output_types.addInt("depth");
+        output_types.addVarchar(WIDTH, "path");
+    }
+
+    virtual TransformFunction *createTransformFunction(ServerInterface &srvInterface)
+    { return vt_createFuncObj(srvInterface.allocator, ConnectBy); }
+
+};
+
+RegisterFactory(ConnectByVarcharFactory);


### PR DESCRIPTION
Currently, ConnectBy supports INTEGER inputs as parent ID and child ID. Now, it supports VARCHAR inputs as well. Close #69.